### PR TITLE
Added tooltip for action units on heatmap

### DIFF
--- a/apollo/get_feature_names.gql
+++ b/apollo/get_feature_names.gql
@@ -2,6 +2,7 @@ query get_feature_names {
   get_feature_names: __type(name: "agg_result") {
     fields {
       name
+      description
     }
   }
 }

--- a/components/D3HeatMap.vue
+++ b/components/D3HeatMap.vue
@@ -90,8 +90,7 @@ export default {
     },
     drawChart() {
       // remove old chart if its there
-      d3.select('#chart > *').remove()
-
+      d3.select('#chart').selectAll('*').remove()
       const margin = { top: 0, right: 0, bottom: 50, left: 50 }
       this.chartWidth = this.width - margin.left - margin.right
       this.chartHeight = this.height - margin.top - margin.bottom
@@ -153,7 +152,41 @@ export default {
         .append('g')
         .attr('class', 'axis axis--y')
         .call(d3.axisLeft(this.y))
+      // Tooltip
+      const tooltip = d3
+        .select('#chart')
+        .append('div')
+        .style('opacity', 0)
+        .attr('class', 'tooltip')
+        .style('position', 'absolute')
+        .style('background-color', 'white')
+        .style('border', 'solid')
+        .style('border-width', '2px')
+        .style('border-radius', '5px')
+        .style('padding', '5px')
 
+      this.yAxis
+        .selectAll('.tick')
+        .style('cursor', 'pointer')
+        .data(this.features)
+        ._groups[0].forEach((d) => {
+          d3.select(d)
+            .on('mousemove', function (event, data) {
+              tooltip.transition().duration(200).style('opacity', 0.9)
+              tooltip
+                .html(data.description)
+                .style('left', event.layerX + 70 + 'px')
+                .style('top', event.layerY + 'px')
+            })
+            .on('mouseleave', function (event, d) {
+              tooltip.style('opacity', 0)
+              d3.select(this).style('stroke', 'none').style('opacity', 0.8)
+            })
+            .on('mouseover', function (event, d) {
+              tooltip.style('opacity', 1)
+              d3.select(this).style('stroke', 'black').style('opacity', 1)
+            })
+        })
       // Build color scale
       const myColor = d3.scaleSequential().domain([0, 4]).interpolator(d3.interpolateInferno)
 

--- a/pages/erd.vue
+++ b/pages/erd.vue
@@ -62,6 +62,7 @@ export default {
         .map((field) => ({
           label: field.name,
           active: this.defaultEnabledFeatures.includes(field.name),
+          description: field.description,
         }))
         .filter((filed) => {
           return filed.label !== 'grouped_seconds' && filed.label !== 'min_timestamp'


### PR DESCRIPTION
This PR fixes AB#369

Adds tooltip for Heatmap Y-axis Action unit labels
![Screenshot 2020-09-24 at 12 11 54](https://user-images.githubusercontent.com/21329772/94132146-2a1b4580-fe5f-11ea-8e45-8fa580c7c3a0.png)
