### PR TITLE
Added tooltip for feature description

### DIFF
--- a/pages/erd.vue
+++ b/pages/erd.vue
@@ -20,16 +20,19 @@
               <v-card v-if="reveal" class="transition-fast-in-fast-out v-card--reveal">
                 <v-card-text class="pb-0 featuresPanel">
                   <v-chip-group v-model="selected_features" column multiple>
-                    <v-chip
-                      v-for="(feature, index) in feature_names"
-                      :key="index"
-                      v-model="feature.active"
-                      :value="feature"
-                      filter
-                      outlined
-                    >
-                      {{ feature.label }}
-                    </v-chip>
+                    <div v-for="(feature, index) in feature_names" :key="index">
+                      <v-tooltip bottom lazy v-if="feature.description">
+                        <template #activator="{ on }">
+                          <v-chip v-model="feature.active" :value="feature" v-on="on" filter outlined>
+                            {{ feature.label }}
+                          </v-chip>
+                        </template>
+                        <span>{{ feature.description }}</span>
+                      </v-tooltip>
+                      <v-chip v-else v-model="feature.active" :value="feature" v-on="on" filter outlined>
+                        {{ feature.label }}
+                      </v-chip>
+                    </div>
                   </v-chip-group>
                 </v-card-text>
                 <v-card-actions class="pt-0 justify-end">


### PR DESCRIPTION
Fixes AB#454

This PR adds description for feature in tooltip
<img width="425" alt="Screenshot 2021-02-04 at 11 12 23" src="https://user-images.githubusercontent.com/21329772/106878140-e45a6d80-66d9-11eb-81f2-8ac90c058507.png">
